### PR TITLE
決済時予約詳細&確認画面のHTML, CSS, PHP実装

### DIFF
--- a/html/mycakeapp/src/Controller/CinemaReservationConfirmingController.php
+++ b/html/mycakeapp/src/Controller/CinemaReservationConfirmingController.php
@@ -25,11 +25,13 @@ class CinemaReservationConfirmingController extends CinemaBaseController
             return $this->redirect(['controller' => 'CinemaSchedules', 'action' => 'index']);
         }
 
+        // scheduleにまとめる
         $schedule = $this->Schedules->get($scheduleId, ['contain' => ['Movies']]);
         $start = $schedule['start_datetime'];
-        $schedule['start_datetime'] = $this->Days->__getDayOfTheWeek($start) . $start->format('H:i');
+        $schedule['start'] = $this->Days->__getDayOfTheWeek($start) . $start->format('H:i');
         $end = $schedule['end_datetime'];
-        $schedule['end_datetime'] = $end->format('H:i');
+        $schedule['end'] = $end->format('H:i');
+        $schedule['seatNo'] = $seatNo;
 
         if ($this->request->is('post')) {
             $data = $this->request->getData();
@@ -37,14 +39,14 @@ class CinemaReservationConfirmingController extends CinemaBaseController
 
             if (empty($errors)) {
                 $session = $this->request->getSession();
-                $session->write('profile', $data);
+                $session->write(['profile' => $data, 'schedule' => $schedule]);
 
                 return $this->redirect(['action' => 'confirm']);
             }
             $this->set(compact('errors'));
         }
 
-        $this->set(compact('schedule', 'seatNo'));
+        $this->set(compact('schedule'));
     }
 
     public function confirm()

--- a/html/mycakeapp/src/Controller/CinemaReservationConfirmingController.php
+++ b/html/mycakeapp/src/Controller/CinemaReservationConfirmingController.php
@@ -9,6 +9,7 @@ class CinemaReservationConfirmingController extends CinemaBaseController
     public function initialize()
     {
         parent::initialize();
+        $this->loadModel('BasicRates');
         $this->loadModel('Schedules');
         $this->viewBuilder()->setLayout('quel_cinemas');
         $this->loadComponent('Days');
@@ -33,6 +34,8 @@ class CinemaReservationConfirmingController extends CinemaBaseController
         $schedule['end'] = $end->format('H:i');
         $schedule['seatNo'] = $seatNo;
 
+        $type = $this->BasicRates->find('list', ['valueField' => 'ticket_type'])->toArray();
+
         if ($this->request->is('post')) {
             $data = $this->request->getData();
             $errors = $this->__validateProfile($data);
@@ -46,7 +49,7 @@ class CinemaReservationConfirmingController extends CinemaBaseController
             $this->set(compact('errors'));
         }
 
-        $this->set(compact('schedule'));
+        $this->set(compact('schedule', 'type'));
     }
 
     public function confirm()

--- a/html/mycakeapp/src/Controller/CinemaReservationConfirmingController.php
+++ b/html/mycakeapp/src/Controller/CinemaReservationConfirmingController.php
@@ -24,8 +24,8 @@ class CinemaReservationConfirmingController extends CinemaBaseController
 
                 return $this->redirect(['action' => 'confirm']);
             }
+            $this->set(compact('errors'));
         }
-        $this->set(compact('errors'));
     }
 
     public function confirm()

--- a/html/mycakeapp/src/Controller/CinemaReservationConfirmingController.php
+++ b/html/mycakeapp/src/Controller/CinemaReservationConfirmingController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Controller;
+
+class CinemaReservationConfirmingController extends CinemaBaseController
+{
+    public function initialize()
+    {
+        parent::initialize();
+        $this->viewBuilder()->setLayout('quel_cinemas');
+    }
+
+    public function index()
+    {
+        $this->set('hoge');
+    }
+}

--- a/html/mycakeapp/src/Controller/CinemaReservationConfirmingController.php
+++ b/html/mycakeapp/src/Controller/CinemaReservationConfirmingController.php
@@ -12,20 +12,21 @@ class CinemaReservationConfirmingController extends CinemaBaseController
         parent::initialize();
         $this->loadModel('BasicRates');
         $this->loadModel('Schedules');
+        $this->loadModel('DiscountTypes');
         $this->viewBuilder()->setLayout('quel_cinemas');
         $this->loadComponent('Days');
     }
 
     public function index()
     {
-        // * プレビュー用の暫定的なParameter
-        $scheduleId = 19; // GoPro
-        $seatNo = 'A-1';
-        // * ここまで
-
-        if (empty($scheduleId) || empty($seatNo)) {
+        // Sessionから値を取得する. ない場合はスケジュールへリダイレクトする
+        $session = $this->request->getSession();
+        if (!($session->check('schedule'))) {
             return $this->redirect(['controller' => 'CinemaSchedules', 'action' => 'index']);
         }
+        $schedule = $session->read('schedule');
+        $scheduleId = $schedule['id'];
+        $seatNo = $schedule['seatNo'];
 
         // scheduleにまとめる
         $schedule = $this->Schedules->get($scheduleId, ['contain' => ['Movies']]);

--- a/html/mycakeapp/src/Controller/CinemaReservationConfirmingController.php
+++ b/html/mycakeapp/src/Controller/CinemaReservationConfirmingController.php
@@ -9,11 +9,24 @@ class CinemaReservationConfirmingController extends CinemaBaseController
     public function initialize()
     {
         parent::initialize();
+        $this->loadModel('Schedules');
         $this->viewBuilder()->setLayout('quel_cinemas');
+        $this->loadComponent('Days');
     }
 
     public function index()
     {
+        // * プレビュー用の暫定的なParameter
+        $scheduleId = 19; // GoPro
+        $seatNo = 'A-1';
+        // * ここまで
+
+        $schedule = $this->Schedules->get($scheduleId, ['contain' => ['Movies']]);
+        $start = $schedule['start_datetime'];
+        $schedule['start_datetime'] = $this->Days->__getDayOfTheWeek($start) . $start->format('H:i');
+        $end = $schedule['end_datetime'];
+        $schedule['end_datetime'] = $end->format('H:i');
+
         if ($this->request->is('post')) {
             $data = $this->request->getData();
             $errors = $this->__validateProfile($data);
@@ -26,6 +39,8 @@ class CinemaReservationConfirmingController extends CinemaBaseController
             }
             $this->set(compact('errors'));
         }
+
+        $this->set(compact('schedule', 'seatNo'));
     }
 
     public function confirm()

--- a/html/mycakeapp/src/Controller/CinemaReservationConfirmingController.php
+++ b/html/mycakeapp/src/Controller/CinemaReservationConfirmingController.php
@@ -52,6 +52,9 @@ class CinemaReservationConfirmingController extends CinemaBaseController
     public function confirm()
     {
         $session = $this->request->getSession();
+        $schedule = $session->read('schedule');
+
+        $this->set(compact('schedule'));
     }
 
     private function __validateProfile($data)

--- a/html/mycakeapp/src/Controller/CinemaReservationConfirmingController.php
+++ b/html/mycakeapp/src/Controller/CinemaReservationConfirmingController.php
@@ -21,6 +21,10 @@ class CinemaReservationConfirmingController extends CinemaBaseController
         $seatNo = 'A-1';
         // * ここまで
 
+        if (empty($scheduleId) || empty($seatNo)) {
+            return $this->redirect(['controller' => 'CinemaSchedules', 'action' => 'index']);
+        }
+
         $schedule = $this->Schedules->get($scheduleId, ['contain' => ['Movies']]);
         $start = $schedule['start_datetime'];
         $schedule['start_datetime'] = $this->Days->__getDayOfTheWeek($start) . $start->format('H:i');

--- a/html/mycakeapp/src/Controller/CinemaReservationConfirmingController.php
+++ b/html/mycakeapp/src/Controller/CinemaReservationConfirmingController.php
@@ -70,7 +70,9 @@ class CinemaReservationConfirmingController extends CinemaBaseController
 
         // 割引種類を取得して計算する
         $day = $schedule['start_datetime'];
-        $age = Chronos::createFromDate($profile['year'], $profile['month'], $profile['day'])->age;
+        $born = Chronos::createFromDate($profile['year'], $profile['month'], $profile['day'])->startOfDay();
+        $current = Chronos::parse($schedule['start_datetime']);
+        $age = $born->diffInYears($current);
 
         if ($day->day === 1) {
             $discountType = 'ファーストデイ割引';

--- a/html/mycakeapp/src/Controller/Component/DaysComponent.php
+++ b/html/mycakeapp/src/Controller/Component/DaysComponent.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Controller\Component;
+
+use Cake\Controller\Component;
+
+class DaysComponent extends Component
+{
+    public function __getDayOfTheWeek($day)
+    {
+        $weekday = ['日', '月', '火', '水', '木', '金', '土'];
+        $w = $weekday[$day->format('w')];
+        $day = $day->format("m月d日($w)");
+
+        return $day;
+    }
+}

--- a/html/mycakeapp/src/Controller/ConfirmTestingController.php
+++ b/html/mycakeapp/src/Controller/ConfirmTestingController.php
@@ -15,8 +15,9 @@ class ConfirmTestingController extends AppController
 
     public function index()
     {
-        // GoPro, 11月19日(木)05:00~06:40
-        $scheduleId = 19;
+        // 11月24日(火)00:00~01:40
+        // 2000で20歳, '05で15. '1950で70.
+        $scheduleId = 61;
         $seatNo = 'A-1';
 
         $this->__testSubmit($scheduleId, $seatNo);
@@ -24,15 +25,24 @@ class ConfirmTestingController extends AppController
 
     public function wed()
     {
-        // 11月18日(水)00:00~01:40
-        // 2000-11-11.で20歳, '05で15. '1950で70.
-        $scheduleId = 1;
-        // TODO:年齢は今日じゃなくてその日やで.
-        // TODO:フォームの値が保持されていない
+        // 11月25日(水)00:00~01:40
+        // 子供女性シニア割引, ... 'female') || ($age <= 15) || ($age >= 70)
+        $scheduleId = 62;
         $seatNo = 'B-1';
 
         $this->__testSubmit($scheduleId, $seatNo);
     }
+
+    public function first()
+    {
+        // 12月01日(水)00:00~01:40
+        // ファーストデイ割引, 誰でも500yenオフ
+        $scheduleId = 63;
+        $seatNo = 'C-1';
+
+        $this->__testSubmit($scheduleId, $seatNo);
+    }
+
 
     private function __testSubmit($scheduleId, $seatNo)
     {

--- a/html/mycakeapp/src/Controller/ConfirmTestingController.php
+++ b/html/mycakeapp/src/Controller/ConfirmTestingController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Controller;
+
+use App\Controller\AppController;
+
+class ConfirmTestingController extends AppController
+{
+    public function initialize()
+    {
+        parent::initialize();
+        $this->loadModel('Schedules');
+        $this->loadComponent('Days');
+    }
+
+    public function index()
+    {
+        // GoPro, 11月19日(木)05:00~06:40
+        $scheduleId = 19;
+        $seatNo = 'A-1';
+
+        $this->__testSubmit($scheduleId, $seatNo);
+    }
+
+    public function wed()
+    {
+        // 11月18日(水)00:00~01:40
+        // 2000-11-11.で20歳, '05で15. '1950で70.
+        $scheduleId = 1;
+        // TODO:年齢は今日じゃなくてその日やで.
+        // TODO:フォームの値が保持されていない
+        $seatNo = 'B-1';
+
+        $this->__testSubmit($scheduleId, $seatNo);
+    }
+
+    private function __testSubmit($scheduleId, $seatNo)
+    {
+        $schedule = $this->Schedules->get($scheduleId, ['contain' => ['Movies']]);
+        $start = $schedule['start_datetime'];
+        $schedule['start'] = $this->Days->__getDayOfTheWeek($start) . $start->format('H:i');
+        $end = $schedule['end_datetime'];
+        $schedule['end'] = $end->format('H:i');
+        $schedule['seatNo'] = $seatNo;
+
+        $session = $this->request->getSession();
+        $session->write(['schedule' => $schedule]);
+
+        return $this->redirect(['controller' => 'CinemaReservationConfirming', 'action' => 'index']);
+    }
+}

--- a/html/mycakeapp/src/Template/CinemaReservationConfirming/confirm.ctp
+++ b/html/mycakeapp/src/Template/CinemaReservationConfirming/confirm.ctp
@@ -1,15 +1,17 @@
 <?php $this->Html->css('cinemaReservationConfirming.css', ['block' => true]) ?>
 
 <div class="innerWindow-confirm">
+    <?= $this->Form->create() ?>
     <div class="beingConfirmed-confirm">
         <p class="title"><?= $schedule['movie']['title'] ?></p>
         <p class="date"><?= $schedule['start'] ?>~<span class="endTime"><?= $schedule['end'] ?></span></p>
         <p class="seat">座席：<?= $schedule['seatNo'] ?></p>
-        <p class="price">&yen;1,111</p>
-        <p class="discount"><?= true ? 'レディースデー割引' : '' ?></p>
+        <p class="price"><?= $price ?></p>
+        <p class="discount"><?= $discountType ?></p>
     </div>
     <div class="buttons">
         <?= $this->Html->link('キャンセル', ['controller' => $this->request->getParam('controller'), 'action' => 'index'], ['class' => 'cancel']); ?>
         <?= $this->Form->button('決定', ['class' => 'submit']) ?>
+        <?= $this->Form->end() ?>
     </div>
 </div>

--- a/html/mycakeapp/src/Template/CinemaReservationConfirming/confirm.ctp
+++ b/html/mycakeapp/src/Template/CinemaReservationConfirming/confirm.ctp
@@ -1,0 +1,15 @@
+<?php $this->Html->css('cinemaReservationConfirming.css', ['block' => true]) ?>
+
+<div class="innerWindow-confirm">
+    <div class="beingConfirmed-confirm">
+        <p class="title"><?= $schedule['movie']['title'] ?></p>
+        <p class="date"><?= $schedule['start'] ?>~<span class="endTime"><?= $schedule['end'] ?></span></p>
+        <p class="seat">座席：<?= $schedule['seatNo'] ?></p>
+        <p class="price">&yen;1,111</p>
+        <p class="discount"><?= true ? 'レディースデー割引' : '' ?></p>
+    </div>
+    <div class="buttons">
+        <?= $this->Html->link('キャンセル', ['controller' => $this->request->getParam('controller'), 'action' => 'index'], ['class' => 'cancel']); ?>
+        <?= $this->Form->button('決定', ['class' => 'submit']) ?>
+    </div>
+</div>

--- a/html/mycakeapp/src/Template/CinemaReservationConfirming/index.ctp
+++ b/html/mycakeapp/src/Template/CinemaReservationConfirming/index.ctp
@@ -11,14 +11,14 @@
         <div class="inner-box">
             <p class="input-p">性別</p>
             <div class="input-radio">
-                <?= $this->Form->radio('sex', ['男性', '女性'], ['required']); ?>
+                <?= $this->Form->radio('sex', ['male' => '男性', 'female' => '女性'], ['required']); ?>
             </div>
             <p class="error-message"><?= isset($errors['sex']) ? array_pop($errors['sex']) : '' ?></p>
         </div>
         <div class="inner-box">
             <p class="input-p">種類</p>
             <div class="input-select">
-                <?= $this->Form->select('type', ['一般', '大学生', '高校生', '小中学生', '幼児（3歳以上）']); ?>
+                <?= $this->Form->select('type', $type); ?>
             </div>
             <p class="error-message"><?= isset($errors['type']) ? array_pop($errors['type']) : '' ?></p>
         </div>

--- a/html/mycakeapp/src/Template/CinemaReservationConfirming/index.ctp
+++ b/html/mycakeapp/src/Template/CinemaReservationConfirming/index.ctp
@@ -38,7 +38,7 @@
         </div>
     </fieldset>
     <div class="buttons">
-        <?= $this->Form->button('キャンセル', ['class' => 'cancel', 'type' => 'button', 'onclick' => 'history.back()']); ?>
+        <?= $this->Html->link('キャンセル', ['controller' => $this->request->getParam('controller'), 'action' => 'index'], ['class' => 'cancel']); ?>
         <?= $this->Form->button('決定', ['class' => 'submit']) ?>
         <?= $this->Form->end() ?>
     </div>

--- a/html/mycakeapp/src/Template/CinemaReservationConfirming/index.ctp
+++ b/html/mycakeapp/src/Template/CinemaReservationConfirming/index.ctp
@@ -2,8 +2,8 @@
 
 <div class="beingConfirmed">
     <p><?= $schedule['movie']['title'] ?></p>
-    <p><?= $schedule['start_datetime'] ?>~<span class="endTime"><?= $schedule['end_datetime'] ?></span></p>
-    <p class="seat">座席：<?= $seatNo ?></p>
+    <p><?= $schedule['start'] ?>~<span class="endTime"><?= $schedule['end'] ?></span></p>
+    <p class="seat">座席：<?= $schedule['seatNo'] ?></p>
 </div>
 <div class="innerWindow">
     <?= $this->Form->create() ?>

--- a/html/mycakeapp/src/Template/CinemaReservationConfirming/index.ctp
+++ b/html/mycakeapp/src/Template/CinemaReservationConfirming/index.ctp
@@ -1,9 +1,9 @@
 <?php $this->Html->css('cinemaReservationConfirming.css', ['block' => true]) ?>
 
 <div class="beingConfirmed">
-    <p>映画タイトル</p>
-    <p>00月00日(月)00:00~<span class="endTime">00:00</span></p>
-    <p class="seat">座席：A-1</p>
+    <p><?= $schedule['movie']['title'] ?></p>
+    <p><?= $schedule['start_datetime'] ?>~<span class="endTime"><?= $schedule['end_datetime'] ?></span></p>
+    <p class="seat">座席：<?= $seatNo ?></p>
 </div>
 <div class="innerWindow">
     <?= $this->Form->create() ?>

--- a/html/mycakeapp/src/Template/CinemaReservationConfirming/index.ctp
+++ b/html/mycakeapp/src/Template/CinemaReservationConfirming/index.ctp
@@ -1,0 +1,40 @@
+<?php $this->Html->css('cinemaReservationConfirming.css', ['block' => true]) ?>
+
+<div class="beingConfirmed">
+    <p>映画タイトル</p>
+    <p>00月00日(月)00:00~<span class="endTime">00:00</span></p>
+    <p class="seat">座席：A-1</p>
+</div>
+<div class="innerWindow">
+    <?= $this->Form->create($hoge) ?>
+    <fieldset>
+        <div class="inner-box">
+            <p class="input-p">性別</p>
+            <div class="input-radio">
+                <?= $this->Form->radio('sex', ['男性', '女性'], ['required']); ?>
+            </div>
+        </div>
+        <div class="inner-box">
+            <p class="input-p">種類</p>
+            <div class="input-select">
+                <?= $this->Form->select('type', ['一般', '大学生', '高校生', '小中学生', '幼児（3歳以上）']); ?>
+            </div>
+        </div>
+        <div class="inner-box">
+            <p class="input-p">生年月日</p>
+            <div class="input-text">
+                <?= $this->Form->text('year', ['required']); ?>
+                <p class="text-by">年</p>
+                <?= $this->Form->text('month', ['required']); ?>
+                <p class="text-by">月</p>
+                <?= $this->Form->text('day', ['required']); ?>
+                <p class="text-by">日</p>
+            </div>
+        </div>
+    </fieldset>
+    <div class="buttons">
+        <?= $this->Form->button('キャンセル', ['class' => 'cancel', 'type' => 'button', 'onclick' => 'history.back()']); ?>
+        <?= $this->Form->button('決定', ['class' => 'submit']) ?>
+        <?= $this->Form->end() ?>
+    </div>
+</div>

--- a/html/mycakeapp/src/Template/CinemaReservationConfirming/index.ctp
+++ b/html/mycakeapp/src/Template/CinemaReservationConfirming/index.ctp
@@ -6,19 +6,21 @@
     <p class="seat">座席：A-1</p>
 </div>
 <div class="innerWindow">
-    <?= $this->Form->create($hoge) ?>
+    <?= $this->Form->create() ?>
     <fieldset>
         <div class="inner-box">
             <p class="input-p">性別</p>
             <div class="input-radio">
                 <?= $this->Form->radio('sex', ['男性', '女性'], ['required']); ?>
             </div>
+            <p class="error-message"><?= isset($errors['sex']) ? array_pop($errors['sex']) : '' ?></p>
         </div>
         <div class="inner-box">
             <p class="input-p">種類</p>
             <div class="input-select">
                 <?= $this->Form->select('type', ['一般', '大学生', '高校生', '小中学生', '幼児（3歳以上）']); ?>
             </div>
+            <p class="error-message"><?= isset($errors['type']) ? array_pop($errors['type']) : '' ?></p>
         </div>
         <div class="inner-box">
             <p class="input-p">生年月日</p>
@@ -30,6 +32,9 @@
                 <?= $this->Form->text('day', ['required']); ?>
                 <p class="text-by">日</p>
             </div>
+            <p class="error-message"><?= isset($errors['year']) ? array_pop($errors['year']) : '' ?></p>
+            <p class="error-message"><?= isset($errors['month']) ? array_pop($errors['month']) : '' ?></p>
+            <p class="error-message"><?= isset($errors['day']) ? array_pop($errors['day']) : '' ?></p>
         </div>
     </fieldset>
     <div class="buttons">

--- a/html/mycakeapp/webroot/css/cinemaReservationConfirming.css
+++ b/html/mycakeapp/webroot/css/cinemaReservationConfirming.css
@@ -10,6 +10,19 @@ body {
     padding: 108px 0 88px 0;
 }
 
+.innerWindow-confirm {
+    width: 736px;
+    margin: 230px auto 100px;
+    background-color: #ffffff;
+    text-align: center;
+    padding: 108px 0 88px 0;
+}
+
+.innerWindow,
+.innerWindow-confirm {
+    box-shadow: 0px 0px 6px #00000029;
+}
+
 .innerWindow fieldset {
     border: none;
     width: 336px;
@@ -49,8 +62,48 @@ body {
     line-height: 37px;
 }
 
-.innerWindow {
-    box-shadow: 0px 0px 6px #00000029;
+.beingConfirmed-confirm {
+    margin: 0 0 73px;
+}
+
+.beingConfirmed-confirm p {
+    text-align: center;
+    color: #707070;
+}
+
+.beingConfirmed-confirm .title {
+    font: normal normal bold 18px/24px Noto Sans;
+    letter-spacing: 1.44px;
+    margin: 0 0 22px;
+}
+
+.beingConfirmed-confirm .date {
+    font: normal normal bold 17px/23px Noto Sans;
+    letter-spacing: 1.36px;
+    margin: 0 0 24px;
+}
+
+.beingConfirmed-confirm .endTime {
+    font: normal normal bold 15px/20px sans-serif;
+    letter-spacing: 1.2px;
+}
+
+.beingConfirmed-confirm .seat {
+    font: normal normal bold 19px/26px sans-serif;
+    letter-spacing: 1.52px;
+    margin: 0 0 22px;
+}
+
+.beingConfirmed-confirm .price {
+    font: normal normal bold 20px/27px sans-serif;
+    letter-spacing: 1.6px;
+    margin: 0 0 23px;
+}
+
+.beingConfirmed-confirm .discount {
+    font: normal normal bold 13px/18px Noto Sans;
+    letter-spacing: 1.04px;
+    color: #f5aa00;
 }
 
 .inner-box {
@@ -151,5 +204,43 @@ fieldset div:nth-child(3) {
 
 .innerWindow a:hover,
 .innerWindow button:hover {
+    box-shadow: 2px 2px 12px rgba(0, 0, 0, 0.3);
+}
+
+.innerWindow-confirm .buttons {
+    display: flex;
+    justify-content: space-between;
+    align-items: stretch;
+    width: 336px;
+    height: 48px;
+    margin: 0 auto;
+}
+
+.innerWindow-confirm a.cancel {
+    width: 128px;
+    background: #efefef 0% 0% no-repeat padding-box;
+    box-shadow: 0px 2px 2px #00000014;
+    border: none;
+    font: normal normal normal 16px/22px sans-serif;
+    letter-spacing: 0.44px;
+    color: #707070;
+    line-height: 48px;
+}
+
+.innerWindow-confirm button.submit {
+    width: 192px;
+    background: #f5ae0b 0% 0% no-repeat padding-box;
+    box-shadow: 0px 2px 2px #00000015;
+    margin: 0;
+    padding: 0;
+    font: normal normal normal 16px/22px sans-serif;
+    letter-spacing: 0.44px;
+    color: #ffffff;
+    border: none;
+    cursor: pointer;
+}
+
+.innerWindow-confirm a:hover,
+.innerWindow-confirm button:hover {
     box-shadow: 2px 2px 12px rgba(0, 0, 0, 0.3);
 }

--- a/html/mycakeapp/webroot/css/cinemaReservationConfirming.css
+++ b/html/mycakeapp/webroot/css/cinemaReservationConfirming.css
@@ -1,0 +1,143 @@
+body {
+    background-color: #ebebeb;
+}
+
+.innerWindow {
+    width: 736px;
+    margin: 0 auto 100px;
+    background-color: #ffffff;
+    text-align: center;
+    padding: 108px 0 88px 0;
+}
+
+.innerWindow fieldset {
+    border: none;
+    width: 336px;
+    margin: 0 auto;
+    padding: 0;
+}
+
+.beingConfirmed {
+    margin: 79px 0 40px;
+}
+
+.beingConfirmed p {
+    text-align: center;
+    font: normal normal bold 19px/26px sans-serif;
+    letter-spacing: 1.52px;
+    color: #707070;
+    opacity: 0.6;
+    line-height: 37px;
+}
+
+.beingConfirmed .endTime,
+.beingConfirmed .seat {
+    font: normal normal bold 15px/20px sans-serif;
+    letter-spacing: 1.2px;
+}
+
+.beingConfirmed .seat {
+    line-height: 37px;
+}
+
+.innerWindow {
+    box-shadow: 0px 0px 6px #00000029;
+}
+
+.inner-box {
+    width: 208px;
+    margin: 0 auto 42px;
+    text-align: left;
+}
+
+.inner-box p.input-p {
+    font: normal normal 600 13px/18px sans-serif;
+    letter-spacing: 1.04px;
+    color: #707070;
+    margin: 0 0 16px;
+}
+
+.inner-box div.input-radio {
+    display: flex;
+    justify-content: space-between;
+    font: normal normal bold 17px/23px sans-serif;
+    letter-spacing: 1.36px;
+    color: #707070;
+}
+
+.inner-box div.input-radio label {
+    display: flex;
+    width: 60px;
+    justify-content: space-between;
+    align-items: baseline;
+}
+
+.inner-box select[name="type"] {
+    height: 24px;
+}
+
+.inner-box .input-text {
+    display: flex;
+    justify-content: flex-start;
+    align-items: baseline;
+}
+.inner-box input[type="text"] {
+    margin: 0 3px 0 0;
+}
+
+.inner-box input[name="year"] {
+    width: 48px;
+    height: 18px;
+}
+
+.inner-box input[name="month"],
+.inner-box input[name="day"] {
+    width: 32px;
+    height: 18px;
+}
+
+fieldset div:nth-child(3) {
+    margin-bottom: 56px;
+}
+
+.inner-box p.text-by {
+    font: normal normal 600 15px/20px sans-serif;
+    letter-spacing: 1.2px;
+    color: #707070;
+    margin: 0 10px 0 0;
+}
+
+.innerWindow .buttons {
+    display: flex;
+    justify-content: space-between;
+    align-items: stretch;
+    width: 336px;
+    height: 48px;
+    margin: 0 auto;
+}
+
+.innerWindow button.cancel {
+    width: 128px;
+    background: #efefef 0% 0% no-repeat padding-box;
+    box-shadow: 0px 2px 2px #00000014;
+    border: none;
+    font: normal normal normal 16px/22px sans-serif;
+    letter-spacing: 0.44px;
+    color: #707070;
+}
+
+.innerWindow button.submit {
+    width: 192px;
+    background: #f5ae0b 0% 0% no-repeat padding-box;
+    box-shadow: 0px 2px 2px #00000015;
+    margin: 0;
+    padding: 0;
+    font: normal normal normal 16px/22px sans-serif;
+    letter-spacing: 0.44px;
+    color: #ffffff;
+    border: none;
+}
+
+.innerWindow button:hover {
+    box-shadow: 2px 2px 12px rgba(0, 0, 0, 0.3);
+}

--- a/html/mycakeapp/webroot/css/cinemaReservationConfirming.css
+++ b/html/mycakeapp/webroot/css/cinemaReservationConfirming.css
@@ -125,7 +125,7 @@ fieldset div:nth-child(3) {
     margin: 0 auto;
 }
 
-.innerWindow button.cancel {
+.innerWindow a.cancel {
     width: 128px;
     background: #efefef 0% 0% no-repeat padding-box;
     box-shadow: 0px 2px 2px #00000014;
@@ -133,6 +133,7 @@ fieldset div:nth-child(3) {
     font: normal normal normal 16px/22px sans-serif;
     letter-spacing: 0.44px;
     color: #707070;
+    line-height: 48px;
 }
 
 .innerWindow button.submit {
@@ -145,8 +146,10 @@ fieldset div:nth-child(3) {
     letter-spacing: 0.44px;
     color: #ffffff;
     border: none;
+    cursor: pointer;
 }
 
+.innerWindow a:hover,
 .innerWindow button:hover {
     box-shadow: 2px 2px 12px rgba(0, 0, 0, 0.3);
 }

--- a/html/mycakeapp/webroot/css/cinemaReservationConfirming.css
+++ b/html/mycakeapp/webroot/css/cinemaReservationConfirming.css
@@ -30,6 +30,15 @@ body {
     line-height: 37px;
 }
 
+.error-message {
+    text-align: left;
+    font: normal normal normal 13px/18px sans-serif;
+    letter-spacing: 1.04px;
+    color: red;
+    margin: 7.5px 0 0;
+    /* line-height: 26px; */
+}
+
 .beingConfirmed .endTime,
 .beingConfirmed .seat {
     font: normal normal bold 15px/20px sans-serif;


### PR DESCRIPTION
### やったこと

- 決済時予約詳細&確認画面のHTML, CSS, PHP実装
- 仕様の追加
    - お客様が身分を選択できるセレクトボックスを追加. 身分により基本料金が変わるため.
    - 適用する割引が複数ある場合は, 割引金額が大きいものを優先する. UXのため.
- スケジュール情報を入力するドライバーをテスト用で追加.
    - 直接, 決済時予約詳細/確認に飛ぶとスケジュール情報がないために, スケジュールページへRedirectされるため.

### やっていないこと

- 予約テーブルへの登録. 決済IDが必要となるため.
- 身分と生年月日の組み合わせの検証. 学生の身分は明確に年齢が定まっていないのと, 実際では入場時に身分確認を行うため.

### テストデータのURL

- .csv
    - https://drive.google.com/file/d/1YqshBDpUhpl-xHR05_d0m-RjWM3ssQ-A/view?usp=sharing

- テストデータをphpMyAdminでインポートする際は一行目のQueryをスキップしてください.

### ドライバーのURL(※URLに飛ぶ前にはテストデータをインポートしておいてください)

- 通常
    - http://localhost:10380/confirm-testing
- 水曜:子供女性シニア割引
    - http://localhost:10380/confirm-testing/wed
- 1日:ファーストデイ割引
    - http://localhost:10380/confirm-testing/first
